### PR TITLE
JS Stepper, Merkelizer, DisputeMock

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "author": "johannbarbie@me.com",
   "license": "ISC",
   "dependencies": {
-    "openzeppelin-solidity": "github:OpenZeppelin/openzeppelin-solidity#v2.1.0-rc.2"
+    "openzeppelin-solidity": "github:OpenZeppelin/openzeppelin-solidity#v2.1.0-rc.2",
+    "ethereumjs-vm": "github:pinkiebell/ethereumjs-vm.git#distR1"
   }
 }

--- a/test/dispute.js
+++ b/test/dispute.js
@@ -1,0 +1,315 @@
+
+import Merkelizer from '../utils/Merkelizer';
+import DisputeMock from '../utils/DisputeMock';
+import OffchainStepper from '../utils/OffchainStepper';
+
+// for additional logging
+const DEBUG = false;
+const OP = require('./helpers/constants');
+
+function debugLog (...args) {
+  if (DEBUG) {
+    console.log(...args);
+  }
+}
+
+function submitProofHelper (dispute, code, computationPath) {
+  const prevOutput = computationPath.left.executionState.output;
+  const execState = computationPath.right.executionState;
+  const input = execState.input;
+
+  const proofs = {
+    stackHash: Merkelizer.stackHash(
+      prevOutput.stack.slice(0, prevOutput.stack.length - input.compactStack.length)
+    ),
+    memHash: execState.isMemoryRequired ? '' : Merkelizer.memHash(prevOutput.mem),
+    dataHash: execState.isCallDataRequired ? '' : Merkelizer.dataHash(input.data),
+  };
+
+  return dispute.submitProof(
+    proofs,
+    {
+      // TODO: compact {code,returnData}, support for accounts
+      // code: input.code,
+      code: code,
+      data: execState.isCallDataRequired ? input.data : '',
+      stack: input.compactStack,
+      mem: execState.isMemoryRequired ? input.mem : '',
+      returnData: input.returnData,
+      pc: input.pc,
+      logHash: input.logHash,
+      gasRemaining: input.gasRemaining,
+    }
+  );
+}
+
+async function disputeGame (code, solverSteps, challengerSteps, expectedWinner, expectedError) {
+  try {
+    const stepper = OffchainStepper;
+    const solverMerkle = new Merkelizer().run(solverSteps);
+    const challengerMerkle = new Merkelizer().run(challengerSteps);
+
+    if (DEBUG) {
+      debugLog('solver depth=' + solverMerkle.depth);
+      solverMerkle.printTree();
+      debugLog('challenger depth=' + challengerMerkle.depth);
+      challengerMerkle.printTree();
+    }
+
+    let solverComputationPath = solverMerkle.root;
+    let challengerComputationPath = challengerMerkle.root;
+
+    // TODO: handle the bigger case too
+    if (solverMerkle.depth < challengerMerkle.depth) {
+      challengerComputationPath = challengerMerkle.tree[solverMerkle.depth][0];
+    }
+
+    const dispute = new DisputeMock(
+      solverComputationPath,
+      challengerComputationPath,
+      solverMerkle.depth,
+      code,
+      stepper
+    );
+
+    while (true) {
+      if (solverComputationPath.isLeaf && challengerComputationPath.isLeaf) {
+        debugLog('REACHED leaves');
+
+        debugLog('Solver: SUBMITTING FOR l=' +
+          solverComputationPath.left.hash + ' r=' + solverComputationPath.right.hash);
+        await submitProofHelper(dispute, code, solverComputationPath);
+
+        debugLog('Challenger: SUBMITTING FOR l=' +
+          challengerComputationPath.left.hash + ' r=' + challengerComputationPath.right.hash);
+        await submitProofHelper(dispute, code, challengerComputationPath);
+
+        let winner = dispute.decideOutcome();
+        debugLog('winner=' + winner);
+
+        assert.equal(winner, expectedWinner, 'winner should match fixture');
+        break;
+      }
+
+      if (!solverComputationPath.isLeaf) {
+        let solverPath = dispute.solverPath;
+        let nextPath = solverMerkle.getNode(solverPath);
+
+        if (!nextPath) {
+          debugLog('solver: submission already made by another party');
+          solverComputationPath = solverMerkle.getPair(dispute.solver.left.hash, dispute.solver.right.hash);
+          continue;
+        }
+
+        if (solverComputationPath.left.hash === solverPath) {
+          debugLog('solver goes left from ' +
+            solverComputationPath.hash.substring(2, 6) + ' to ' +
+            solverComputationPath.left.hash.substring(2, 6)
+          );
+        } else if (solverComputationPath.right.hash === solverPath) {
+          debugLog('solver goes right from ' +
+            solverComputationPath.hash.substring(2, 6) + ' to ' +
+            solverComputationPath.right.hash.substring(2, 6)
+          );
+        }
+
+        solverComputationPath = nextPath;
+
+        dispute.respond(solverComputationPath);
+      }
+
+      if (!challengerComputationPath.isLeaf) {
+        let challengerPath = dispute.challengerPath;
+        let nextPath = challengerMerkle.getNode(challengerPath);
+
+        if (!nextPath) {
+          debugLog('challenger submission already made by another party');
+          challengerComputationPath =
+            challengerMerkle.getPair(dispute.challenger.left.hash, dispute.challenger.right.hash);
+          continue;
+        }
+
+        if (challengerComputationPath.left.hash === challengerPath) {
+          debugLog('challenger goes left from ' +
+            challengerComputationPath.hash.substring(2, 6) + ' to ' +
+            challengerComputationPath.left.hash.substring(2, 6)
+          );
+        } else if (challengerComputationPath.right.hash === challengerPath) {
+          debugLog('challenger goes right from ' +
+            challengerComputationPath.hash.substring(2, 6) + ' to ' +
+            challengerComputationPath.right.hash.substring(2, 6)
+          );
+        }
+
+        challengerComputationPath = nextPath;
+
+        dispute.respond(challengerComputationPath);
+      }
+    }
+  } catch (e) {
+    if (expectedError) {
+      assert.equal(e.message, expectedError);
+      return;
+    }
+
+    throw e;
+  }
+}
+
+contract('JS DisputeMock', function () {
+  const code = [
+    OP.PUSH1, '03',
+    OP.PUSH1, '05',
+    OP.ADD,
+    OP.PUSH1, 'ff',
+    OP.PUSH1, '00',
+    OP.MSTORE,
+    OP.PUSH1, '00',
+    OP.MLOAD,
+    OP.PUSH1, '00',
+    OP.MSTORE,
+    OP.PUSH1, 'ff',
+    OP.POP,
+    OP.PUSH1, '00',
+    OP.PUSH1, '01',
+    OP.DUP1,
+    OP.SWAP1,
+    OP.CALLDATASIZE,
+    OP.CALLDATACOPY,
+    OP.GASLIMIT,
+    OP.PUSH1, '01',
+    OP.MSTORE,
+    OP.PUSH1, '00',
+    OP.PUSH1, '01',
+    OP.LOG0,
+    OP.PUSH1, '00',
+    OP.PUSH1, '01',
+    OP.SHA3,
+    OP.PUSH1, '20',
+    OP.PUSH1, '00',
+    OP.RETURN,
+  ];
+  const data = '0x00010203040506070809';
+  const stepper = OffchainStepper;
+
+  let steps;
+  let copy;
+
+  before(async () => {
+    steps = await stepper.run({ code, data });
+    copy = JSON.stringify(steps);
+  });
+
+  it('both have the same result, solver wins', async () => {
+    await disputeGame(code, steps, steps, 'solver');
+  });
+
+  it('challenger has an output error somewhere', async () => {
+    let wrongExecution = JSON.parse(copy);
+    wrongExecution[6].output.compactStack.push('01');
+    wrongExecution[6].output.stack.push('01');
+    await disputeGame(code, steps, wrongExecution, 'solver');
+  });
+
+  it('solver has an output error somewhere', async () => {
+    let wrongExecution = JSON.parse(copy);
+    wrongExecution[6].output.compactStack.push('01');
+    wrongExecution[6].output.stack.push('01');
+    await disputeGame(code, wrongExecution, steps, 'challenger');
+  });
+
+  it('challenger first step missing', async () => {
+    let wrongExecution = JSON.parse(copy);
+    wrongExecution.shift();
+    await disputeGame(code, steps, wrongExecution, 'solver');
+    // TODO: how to proof valid or invalid if solver misses first step?
+  });
+
+  it('challenger last step gone', async () => {
+    let wrongExecution = JSON.parse(copy);
+    wrongExecution.pop();
+    await disputeGame(code, steps, wrongExecution, 'solver');
+  });
+
+  it('solver last step gone', async () => {
+    let wrongExecution = JSON.parse(copy);
+    wrongExecution.pop();
+    await disputeGame(code, wrongExecution, steps, 'challenger');
+  });
+
+  it('challenger wrong memory output', async () => {
+    let wrongExecution = JSON.parse(copy);
+    for (let i = 1; i < wrongExecution.length; i += 2) {
+      wrongExecution[i].output.mem += '00';
+    }
+    await disputeGame(code, steps, wrongExecution, 'solver');
+  });
+
+  it('solver wrong memory output', async () => {
+    let wrongExecution = JSON.parse(copy);
+    for (let i = 1; i < wrongExecution.length; i += 2) {
+      wrongExecution[i].output.mem += '00';
+    }
+    await disputeGame(code, wrongExecution, steps, 'challenger');
+  });
+
+  it('challenger wrong stack output', async () => {
+    let wrongExecution = JSON.parse(copy);
+    for (let i = 1; i < wrongExecution.length; i += 2) {
+      wrongExecution[i].output.compactStack.push('00');
+      wrongExecution[i].output.stack.push('00');
+    }
+    await disputeGame(code, steps, wrongExecution, 'solver');
+  });
+
+  it('solver wrong stack output', async () => {
+    let wrongExecution = JSON.parse(copy);
+    for (let i = 1; i < wrongExecution.length; i += 2) {
+      wrongExecution[i].output.compactStack.push('00');
+      wrongExecution[i].output.stack.push('00');
+    }
+
+    await disputeGame(code, wrongExecution, steps, 'challenger');
+  });
+
+  it('challenger wrong opcode', async () => {
+    let wrongExecution = JSON.parse(copy);
+    for (let i = 1; i < wrongExecution.length; i += 3) {
+      wrongExecution[i].output.code = ['01'];
+      wrongExecution[i].output.pc += 1;
+    }
+    await disputeGame(code, steps, wrongExecution, 'solver');
+  });
+
+  it('solver wrong opcode', async () => {
+    let wrongExecution = JSON.parse(copy);
+    for (let i = 1; i < wrongExecution.length; i += 3) {
+      wrongExecution[i].output.code = ['01'];
+      wrongExecution[i].output.pc += 1;
+    }
+    await disputeGame(code, wrongExecution, steps, 'challenger');
+  });
+
+  it('only two steps, both wrong but doesn\'t end with REVERT or RETURN = challenger wins', async () => {
+    let wrongExecution = JSON.parse(copy).slice(0, 2);
+    await disputeGame(code, wrongExecution, wrongExecution, 'challenger');
+  });
+
+  it('solver misses steps in between', async () => {
+    let wrongExecution = JSON.parse(copy);
+    wrongExecution = wrongExecution.slice(0, 2).concat(wrongExecution.slice(-3));
+    await disputeGame(code, wrongExecution, steps, 'challenger');
+  });
+
+  it('solver with one invalid step', async () => {
+    let wrongExecution = JSON.parse(copy);
+    wrongExecution[7] = wrongExecution[8];
+    await disputeGame(code, wrongExecution, steps, 'challenger');
+  });
+
+  it('challenger with one invalid step', async () => {
+    let wrongExecution = JSON.parse(copy);
+    wrongExecution[7] = wrongExecution[8];
+    await disputeGame(code, steps, wrongExecution, 'solver');
+  });
+});

--- a/test/ethereumRuntime.js
+++ b/test/ethereumRuntime.js
@@ -101,7 +101,9 @@ contract('Runtime', function () {
           assert.deepEqual(res.mem, fixture.result.memory);
         }
         if (fixture.result.accounts) {
-          fixture.result.accounts.push({
+          const accounts = Array.from(fixture.result.accounts);
+
+          accounts.push({
             address: `0x${DEFAULT_CALLER}`,
             balance: 0,
             nonce: 0,
@@ -111,7 +113,7 @@ contract('Runtime', function () {
           });
           const accs = decodeAccounts(res.accounts, res.accountsCode);
           const accsMap = accs.reduce((m, a) => { m[a.address] = a; return m; }, {});
-          fixture.result.accounts.forEach(account => {
+          accounts.forEach(account => {
             const expectedAccount = accsMap[account.address];
             assert.isTrue(!!expectedAccount);
             if (account.balance) {

--- a/test/stepper.js
+++ b/test/stepper.js
@@ -1,0 +1,103 @@
+
+import { getCode, toBN } from './utils';
+import OffchainStepper from '../utils/OffchainStepper';
+import fixtures from './fixtures';
+
+const ethers = require('ethers');
+
+const fromHextoStr = arr => arr.map(e => toBN('0x' + e).toString());
+const fromMixedToHex = arr => arr.map(e => toBN(e).toHexString('hex'));
+
+contract('JS Stepper', function () {
+  describe('fixtures', async () => {
+    fixtures.forEach(fixture => {
+      const { pc, opcodeUnderTest } = getCode(fixture);
+
+      it(fixture.description || opcodeUnderTest, async () => {
+        const stepper = OffchainStepper;
+        const code = typeof fixture.code === 'object' ? fixture.code : [fixture.code];
+        const stack = fromMixedToHex(fixture.stack || []);
+        const mem = fixture.memory || '';
+        const accounts = fixture.accounts;
+        const data = fixture.data || '';
+        const blockGasLimit = fixture.blockGasLimit;
+        const gasLimit = fixture.gasLimit || blockGasLimit;
+        const logHash = fixture.logHash;
+        const args = {
+          code,
+          data,
+          stack,
+          mem,
+          accounts,
+          logHash,
+          gasLimit,
+          blockGasLimit,
+          pc,
+        };
+        const steps = await stepper.run(args);
+        const res = steps[steps.length - 1];
+
+        let gasUsed = 0;
+        let len = steps.length;
+
+        while (len--) {
+          gasUsed += steps[len].gasFee;
+        }
+
+        if (fixture.result.stack) {
+          assert.deepEqual(fromHextoStr(res.output.stack), fixture.result.stack, 'stack');
+        }
+        if (fixture.result.memory) {
+          let padded = res.output.mem;
+
+          while (padded.length % 64 !== 0) {
+            padded += '00';
+          }
+          assert.equal(padded, fixture.result.memory.replace('0x', ''), 'mem');
+        }
+        if (fixture.result.gasUsed !== undefined) {
+          assert.equal(gasUsed, fixture.result.gasUsed, 'gasUsed');
+        }
+        if (fixture.result.pc !== undefined) {
+          assert.equal(res.output.pc, fixture.result.pc, 'pc');
+        }
+        if (fixture.result.errno !== undefined) {
+          assert.equal(res.output.errno, fixture.result.errno, 'errno');
+        }
+        if (fixture.result.logHash) {
+          assert.equal(res.logHash, fixture.result.logHash, 'logHash');
+        }
+        if (fixture.result.accounts) {
+          const accsMap = res.accounts.reduce((m, a) => { m[a.address] = a; return m; }, {});
+
+          fixture.result.accounts.forEach(account => {
+            const expectedAccount = accsMap[account.address.replace('0x', '')] || {};
+
+            if (account.balance) {
+              assert.equal(expectedAccount.balance, account.balance, 'Account Balance');
+            }
+
+            if (account.storage) {
+              const stgeMap = account.storage.reduce(
+                (m, a) => {
+                  // ignore zero values
+                  // eslint-disable-next-line eqeqeq
+                  if (a.value == 0) {
+                    return m;
+                  }
+
+                  m[ethers.utils.solidityKeccak256(['uint'], [a.address]).replace('0x', '')] =
+                    toBN(a.value).toHexString().replace('0x', '');
+                  return m;
+                },
+                {}
+              );
+
+              assert.deepEqual(expectedAccount.storage, stgeMap, 'Account Storage');
+            }
+          });
+        }
+      });
+    });
+  });
+});

--- a/test/stepper.js
+++ b/test/stepper.js
@@ -65,7 +65,7 @@ contract('JS Stepper', function () {
           assert.equal(res.output.errno, fixture.result.errno, 'errno');
         }
         if (fixture.result.logHash) {
-          assert.equal(res.logHash, fixture.result.logHash, 'logHash');
+          assert.equal(res.output.logHash, fixture.result.logHash, 'logHash');
         }
         if (fixture.result.accounts) {
           const accsMap = res.accounts.reduce((m, a) => { m[a.address] = a; return m; }, {});

--- a/test/stepper.js
+++ b/test/stepper.js
@@ -65,7 +65,7 @@ contract('JS Stepper', function () {
           assert.equal(res.output.errno, fixture.result.errno, 'errno');
         }
         if (fixture.result.logHash) {
-          assert.equal(res.output.logHash, fixture.result.logHash, 'logHash');
+          assert.equal(res.output.logHash, fixture.result.logHash.replace('0x', ''), 'logHash');
         }
         if (fixture.result.accounts) {
           const accsMap = res.accounts.reduce((m, a) => { m[a.address] = a; return m; }, {});

--- a/utils/DisputeMock.js
+++ b/utils/DisputeMock.js
@@ -1,0 +1,218 @@
+
+import Merkelizer from './Merkelizer';
+
+export default class DisputeMock {
+  constructor (solverComputationPath, challengerComputationPath, solverDepth, code, evm) {
+    this.treeDepth = solverDepth;
+
+    this.solver = solverComputationPath;
+    this.challenger = challengerComputationPath;
+
+    this.solverDidRespond = false;
+    this.challengerDidRespond = false;
+
+    this.solverVerified = false;
+    this.challengerVerified = false;
+
+    this.isEndOfExecution = true;
+    this.codeHash = Merkelizer.codeHash(code);
+    this.evm = evm;
+
+    this._updateRound();
+  }
+
+  _updateRound () {
+    this.solverDidRespond = false;
+    this.challengerDidRespond = false;
+
+    const EMPTY_STATE = '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+    if ((this.solver.left.hash === this.challenger.left.hash) &&
+      (this.solver.right.hash !== EMPTY_STATE) &&
+      (this.challenger.right.hash !== EMPTY_STATE)) {
+      // following right
+      this.solverPath = this.solver.right.hash;
+      this.challengerPath = this.challenger.right.hash;
+
+      if (this.isEndOfExecution) {
+        this.isEndOfExecution = true;
+      }
+    } else {
+      // following left
+      this.solverPath = this.solver.left.hash;
+      this.challengerPath = this.challenger.left.hash;
+
+      if (this.solver.right.hash !== EMPTY_STATE) {
+        this.isEndOfExecution = false;
+      }
+    }
+  }
+
+  /*
+   * Solver or Challenger always respond with the next `ComputationPath`
+   * for the path they do not agree on.
+   * If they do not agree on both `left` and `right` they must follow/default
+   * to `left`.
+   */
+  respond (computationPath) {
+    let h = Merkelizer.hash(computationPath.left.hash, computationPath.right.hash);
+
+    if (h !== this.solverPath && h !== this.challengerPath) {
+      throw new Error(
+        `wrong path submitted need ${this.solverPath} or ${this.challengerPath} has ${h}`
+      );
+    }
+
+    if ((h === this.solver.left.hash) || (h === this.solver.right.hash)) {
+      if (this.solverDidRespond) {
+        throw new Error('You can not respond right now');
+      }
+
+      this.solverDidRespond = true;
+      this.solver = computationPath;
+    }
+
+    if ((h === this.challenger.left.hash) || (h === this.challenger.right.hash)) {
+      if (this.challengerDidRespond) {
+        throw new Error('You can not respond right now');
+      }
+
+      this.challengerDidRespond = true;
+      this.challenger = computationPath;
+    }
+
+    if (this.solverDidRespond && this.challengerDidRespond) {
+      this._updateRound();
+    }
+  }
+
+  async computeExecutionState (executionState) {
+    const args = {
+      code: executionState.code,
+      data: executionState.data,
+      stack: executionState.stack,
+      mem: executionState.mem,
+      pc: executionState.isCodeCompacted ? 0 : executionState.pc,
+      logHash: executionState.logHash,
+      gasRemaining: executionState.gasRemaining,
+    };
+
+    // should only be one step for the time being..
+    const steps = await this.evm.run(args);
+    const r = steps[0] ||
+      {
+        output: {
+          data: '',
+          compactStack: [],
+          stack: [],
+          mem: '',
+          returnData: '',
+          pc: 0,
+          errno: 0xff,
+          logHash: '',
+          gasRemaining: 0,
+        },
+      };
+
+    return r;
+  }
+
+  /*
+   * if they agree on `left` but not on `right`,
+   * submitProof (on-chain) verification should be called by challenger and solver
+   * to later decide on the outcome in `decideOutcome`
+   *
+   * Requirements:
+   *  - last execution step must end with either REVERT or RETURN to be considered complete
+   *  - any execution step which does not have errno = 0 or errno = 0x07 (REVERT)
+   *    is considered invalid
+   *  - the left-most (first) execution step must be a `Merkelizer.emptyState`
+   *    TODO: This must be accounted for in a `timeout` function.
+   *
+   * Note: if that doesn't happen, this will finally timeout
+   */
+  async submitProof (proofs, executionInput) {
+    if (this.solverPath === this.challengerPath) {
+      // special case
+    } else if (this.solver.left.hash !== this.challenger.left.hash) {
+      throw new Error('solver.left must match challenger.left');
+    }
+
+    if (Merkelizer.codeHash(executionInput.code) !== this.codeHash) {
+      throw new Error('codeHash does not match');
+    }
+
+    let stackHash = Merkelizer.stackHash(executionInput.stack, proofs.stackHash);
+    let inputHash = Merkelizer.stateHash(executionInput, stackHash, proofs.memHash, proofs.dataHash);
+
+    if (inputHash !== this.solver.left.hash && inputHash !== this.challenger.left.hash) {
+      return 'invalid';
+    }
+
+    let result = await this.computeExecutionState(executionInput);
+    stackHash = Merkelizer.stackHash(result.output.stack, proofs.stackHash);
+    let hash = Merkelizer.stateHash(result.output, stackHash, proofs.memHash, proofs.dataHash);
+
+    // eslint-disable-next-line no-constant-condition
+    if (0) {
+      console.log(
+        {
+          'solver': this.solver,
+          'solverPath': this.solverPath,
+          'challenger': this.challenger,
+          'challengerPath': this.challengerPath,
+          'isEndOfExecution': this.isEndOfExecution,
+          'hash': hash,
+        }
+      );
+    }
+
+    if (hash !== this.solver.right.hash && hash !== this.challenger.right.hash) {
+      return 'invalid';
+    }
+
+    if (hash === this.solver.right.hash) {
+      this.solverVerified = true;
+
+      if (!this.result && result.output.errno !== 0 && result.output.errno !== 0x07) {
+        this.result = 'challenger';
+      }
+
+      if (this.isEndOfExecution) {
+        if (result.opcodeName !== 'REVERT' && result.opcodeName !== 'RETURN') {
+          this.result = 'challenger';
+        }
+      }
+    }
+
+    if (hash === this.challenger.right.hash) {
+      this.challengerVerified = true;
+
+      if (!this.result && result.output.errno !== 0 && result.output.errno !== 0x07) {
+        this.result = 'solver';
+      }
+
+      if (!this.result && this.isEndOfExecution) {
+        if (result.opcodeName !== 'REVERT' && result.opcodeName !== 'RETURN') {
+          this.result = 'solver';
+        }
+      }
+    }
+  }
+
+  decideOutcome () {
+    if (this.result) {
+      return this.result;
+    }
+
+    if (this.solverVerified) {
+      return 'solver';
+    }
+
+    if (this.challengerVerified) {
+      return 'challenger';
+    }
+
+    return 'none';
+  }
+}

--- a/utils/Merkelizer.js
+++ b/utils/Merkelizer.js
@@ -1,0 +1,258 @@
+
+const ethers = require('ethers');
+const EMPTY_STATE = '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+export default class Merkelizer {
+  static getEmptyState (callData) {
+    const DEFAULT_GAS = 0x0fffffffffffff;
+    const ZERO_HASH = '0000000000000000000000000000000000000000000000000000000000000000';
+    const res = {
+      hash: EMPTY_STATE,
+      executionState: {
+        input: {
+          data: callData,
+          compactStack: [],
+          stack: [],
+          mem: '',
+          returnData: '',
+          logHash: ZERO_HASH,
+          pc: 0,
+          gasRemaining: DEFAULT_GAS,
+        },
+        output: {
+          data: callData,
+          compactStack: [],
+          stack: [],
+          mem: '',
+          returnData: '',
+          logHash: ZERO_HASH,
+          pc: 0,
+          errno: 0,
+          gasRemaining: DEFAULT_GAS,
+        },
+      },
+    };
+
+    // Note:
+    //   This value needs to be taken into account for the dispute logic (timeout function).
+    //   If the first (left-most) hash is not the same as this,
+    //   then the solution from that player is invalid
+    res.hash = this.stateHash(res.executionState.output);
+
+    return res;
+  }
+
+  static hash (left, right) {
+    return ethers.utils.solidityKeccak256(
+      ['bytes32', 'bytes32'],
+      [left, right]
+    );
+  }
+
+  static codeHash (code) {
+    return ethers.utils.solidityKeccak256(
+      ['bytes'],
+      ['0x' + code.join('')]
+    );
+  }
+
+  static stackHash (stack, sibling) {
+    let res = sibling || EMPTY_STATE;
+
+    for (var i = 0; i < stack.length; i++) {
+      let h = ethers.utils.solidityKeccak256(
+        ['uint'],
+        ['0x' + stack[i]]
+      );
+      res = this.hash(res, h);
+    }
+
+    return res;
+  }
+
+  static memHash (mem) {
+    return ethers.utils.solidityKeccak256(
+      ['bytes'],
+      ['0x' + mem]
+    );
+  }
+
+  static dataHash (data) {
+    return ethers.utils.solidityKeccak256(
+      ['bytes'],
+      ['0x' + data]
+    );
+  }
+
+  static stateHash (execution, stackHash, memHash, dataHash) {
+    // TODO: implement support for accounts
+    // TODO: compact-{code, returnData, accounts}
+
+    if (!stackHash) {
+      stackHash = this.stackHash(execution.stack);
+    }
+
+    if (!memHash) {
+      memHash = this.memHash(execution.mem);
+    }
+
+    if (!dataHash) {
+      dataHash = this.dataHash(execution.data);
+    }
+
+    return ethers.utils.solidityKeccak256(
+      ['bytes', 'bytes', 'bytes', 'bytes', 'bytes', 'uint', 'uint'],
+      [
+        stackHash,
+        memHash,
+        dataHash,
+        '0x' + execution.logHash,
+        '0x' + execution.returnData,
+        execution.pc,
+        execution.gasRemaining,
+      ]
+    );
+  }
+
+  constructor () {
+    this.tree = [];
+  }
+
+  get root () {
+    return this.tree[this.tree.length - 1][0];
+  }
+
+  get depth () {
+    // we do not count the leaves
+    return this.tree.length - 1;
+  }
+
+  getNode (hash) {
+    let len = this.tree.length;
+
+    while (len--) {
+      let x = this.tree[len];
+
+      let iLen = x.length;
+      while (iLen--) {
+        let y = x[iLen];
+        if (y.hash === hash) {
+          return y;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  getPair (leftHash, rightHash) {
+    let len = this.tree.length;
+
+    while (len--) {
+      let x = this.tree[len];
+
+      let iLen = x.length;
+      while (iLen--) {
+        let y = x[iLen];
+        if (y.left.hash === leftHash && y.right.hash === rightHash) {
+          return y;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  run (executions) {
+    if (!executions || !executions.length) {
+      throw new Error('You need to pass at least one execution step');
+    }
+
+    this.tree = [[]];
+
+    const firstExecutionStep = executions[0];
+    const emptyState = this.constructor.getEmptyState(firstExecutionStep.input.data);
+    const leaves = this.tree[0];
+
+    while (executions.length % 2 !== 0) {
+      executions.push(emptyState.executionState);
+    }
+
+    let prevLeaf = { left: emptyState, right: emptyState };
+    let len = executions.length;
+
+    for (let i = 0; i < len; i++) {
+      let hash = this.constructor.stateHash(executions[i].output);
+      let llen = leaves.push(
+        {
+          left: prevLeaf.right,
+          right: {
+            hash: hash,
+            executionState: executions[i],
+          },
+          hash: this.constructor.hash(prevLeaf.right.hash, hash),
+          isLeaf: true,
+        }
+      );
+
+      prevLeaf = leaves[llen - 1];
+    }
+
+    let level = 1;
+    while (true) {
+      let last = this.tree[level - 1];
+      let cur = [];
+
+      if (last.length === 1) {
+        // done
+        break;
+      }
+
+      let len = last.length;
+      for (let i = 0; i < len; i += 2) {
+        let left = last[i];
+        let right = last[i + 1];
+
+        if (!right) {
+          right = {
+            left: {
+              hash: EMPTY_STATE,
+            },
+            right: {
+              hash: EMPTY_STATE,
+            },
+            hash: EMPTY_STATE,
+          };
+          last.push(right);
+        }
+
+        cur.push(
+          {
+            left: left,
+            right: right,
+            hash: this.constructor.hash(left.hash, right.hash),
+          }
+        );
+      }
+
+      this.tree.push(cur);
+      level++;
+    }
+
+    return this;
+  }
+
+  printTree () {
+    for (let i = 0; i < this.tree.length; i++) {
+      let row = this.tree[i];
+      for (let y = 0; y < row.length; y++) {
+        let e = row[y];
+        const h = e.hash.substring(2, 6);
+        const hl = e.left.hash.substring(2, 6);
+        const hr = e.right.hash.substring(2, 6);
+        process.stdout.write(` [ ${h} (l:${hl} r:${hr}) ] `);
+      }
+      process.stdout.write('\n');
+    }
+  }
+}

--- a/utils/OffchainStepper.js
+++ b/utils/OffchainStepper.js
@@ -1,0 +1,459 @@
+
+const VM = require('ethereumjs-vm');
+const BN = VM.deps.ethUtil.BN;
+const ethers = require('ethers');
+const OP = require('../test/helpers/constants');
+
+const toHex = arr => arr.map(e => e.toString(16));
+const MEMORY_OPCODES =
+  [
+    'SHA3',
+    'MLOAD',
+    'MSIZE',
+    'LOG0',
+    'LOG1',
+    'LOG2',
+    'LOG3',
+    'LOG4',
+    'CREATE',
+    'CALL',
+    'RETURN',
+    'DELEGATECALL',
+    'STATICCALL',
+    'REVERT',
+    'CALLDATACOPY',
+    'CODECOPY',
+    'EXTCODECOPY',
+    'RETURNDATACOPY',
+    'MSTORE',
+    'MSTORE8',
+  ];
+
+const CODE_OPCODES =
+  [
+    'CODECOPY',
+    'CODESIZE',
+    'JUMP',
+    'JUMPI',
+    // PUSH has boundary checks
+    'PUSH1',
+    'PUSH2',
+    'PUSH3',
+    'PUSH4',
+    'PUSH5',
+    'PUSH6',
+    'PUSH7',
+    'PUSH8',
+    'PUSH9',
+    'PUSH10',
+    'PUSH11',
+    'PUSH12',
+    'PUSH13',
+    'PUSH14',
+    'PUSH15',
+    'PUSH16',
+    'PUSH17',
+    'PUSH18',
+    'PUSH19',
+    'PUSH20',
+    'PUSH21',
+    'PUSH22',
+    'PUSH23',
+    'PUSH24',
+    'PUSH25',
+    'PUSH26',
+    'PUSH27',
+    'PUSH28',
+    'PUSH29',
+    'PUSH30',
+    'PUSH31',
+    'PUSH32',
+  ];
+
+// Supported by ethereumjs-vm
+const ERRNO_MAP =
+  {
+
+    'stack overflow': 0x01,
+    'stack underflow': 0x02,
+    'invalid opcode': 0x04,
+    'invalid JUMP': 0x05,
+    'revert': 0x07,
+    'static state change': 0x0b,
+    'out of gas': 0x0d,
+    'internal error': 0xff,
+  };
+
+const ERROR_KEYS = Object.keys(ERRNO_MAP);
+
+const DEFAULT_CONTRACT_ADDRESS = Buffer.from('0f572e5295c57F15886F9b263E2f6d2d6c7b5ec6', 'hex');
+const DEFAULT_CALLER = Buffer.from('cD1722f2947Def4CF144679da39c4C32bDc35681', 'hex');
+
+const ZERO_HASH = '0000000000000000000000000000000000000000000000000000000000000000';
+
+function NumToBuf32 (val) {
+  val = val.toString(16);
+
+  while (val.length !== 64) {
+    val = '0' + val;
+  }
+
+  return Buffer.from(val, 'hex');
+}
+
+export default class OffchainStepper {
+  static async initAccounts (evm, accounts) {
+    return new Promise((resolve, reject) => {
+      let openCallbacks = 0;
+
+      function resolveCallbacks () {
+        if (--openCallbacks === 0) {
+          resolve();
+        }
+      }
+
+      let len = accounts.length;
+
+      while (len--) {
+        let obj = accounts[len];
+        let addr = Buffer.from((obj.address || '').replace('0x', ''), 'hex');
+        let account = new VM.deps.Account();
+
+        account.balance = obj.balance | 0;
+
+        // resolves immediately
+        evm.stateManager.putAccount(addr, account, () => {});
+
+        if (obj.storage) {
+          let storageLen = obj.storage.length;
+
+          while (storageLen--) {
+            let store = obj.storage[storageLen];
+
+            openCallbacks++;
+            evm.stateManager.putContractStorage(
+              addr,
+              NumToBuf32(store.address | 0),
+              NumToBuf32(store.value | 0),
+              resolveCallbacks
+            );
+          }
+        }
+      }
+    });
+  }
+
+  static async dumpTouchedAccounts (evm) {
+    return new Promise(
+      (resolve, reject) => {
+        let res = [];
+        let openCallbacks = 0;
+
+        function storageCallback (obj) {
+          this.storage = obj;
+
+          if (--openCallbacks === 0) {
+            resolve(res);
+          }
+        }
+
+        function callback (err, obj) {
+          if (err) {
+            throw err;
+          }
+
+          let account = {
+            address: this,
+            nonce: obj.nonce.toString('hex'),
+            balance: obj.balance.toString('hex'),
+            stateRoot: obj.stateRoot.toString('hex'),
+            codeHash: obj.codeHash.toString('hex'),
+          };
+          res.push(account);
+
+          evm.stateManager.dumpStorage(this, storageCallback.bind(account));
+        }
+
+        evm.stateManager._touched.forEach(
+          (addr) => {
+            openCallbacks++;
+            evm.stateManager.getAccount(addr, callback.bind(addr));
+          }
+        );
+
+        if (!openCallbacks) {
+          resolve(res);
+        }
+      }
+    );
+  }
+
+  static _onStep (evt, context, code, data, stack, mem, gasRemaining) {
+    if (context.inject) {
+      context.inject = false;
+
+      if (stack) {
+        let len = stack.length;
+        for (let i = 0; i < len; i++) {
+          evt.stack.push(new BN(stack[i].replace('0x', ''), 'hex'));
+        }
+        // For fixing the logic below
+        evt.opcode.out += len;
+      }
+      if (mem) {
+        const tmp = Buffer.from(mem.replace('0x', ''), 'hex');
+        const len = tmp.length;
+
+        for (let i = 0; i < len; i++) {
+          evt.memory.push(tmp[i]);
+          if (i % 32 === 0) {
+            evt.memoryWordCount.iaddn(1);
+          }
+        }
+      }
+
+      if (typeof gasRemaining !== 'undefined') {
+        evt.gasLeft.isub(evt.gasLeft.sub(new BN(gasRemaining)));
+      }
+    }
+
+    evt.stateManager.checkpoint(() => {});
+
+    let isCallDataRequired = false;
+    let opcodeName = evt.opcode.name;
+    if (opcodeName === 'CALLDATASIZE' ||
+      opcodeName === 'CALLDATACOPY' ||
+      opcodeName === 'CALLDATALOAD') {
+      isCallDataRequired = true;
+    }
+
+    let swap1 = parseInt(OP.SWAP1, 16);
+    let swap16 = parseInt(OP.SWAP16, 16);
+    let dup1 = parseInt(OP.DUP1, 16);
+    let dup16 = parseInt(OP.DUP16, 16);
+
+    let opcode = evt.opcode.opcode;
+
+    let stackFixed;
+    if (opcode >= swap1 && opcode <= swap16) {
+      let x = 16 - (swap16 - opcode);
+      stackFixed = toHex(evt.stack.slice(-(x * 2)));
+    }
+
+    if (opcode >= dup1 && opcode <= dup16) {
+      let x = 16 - (dup16 - opcode);
+      stackFixed = toHex(evt.stack.slice(-x));
+    }
+
+    let isMemoryRequired = MEMORY_OPCODES.indexOf(opcodeName) !== -1;
+    let _stack = toHex(evt.stack);
+    let _mem = Buffer.from(evt.memory).toString('hex');
+
+    let pc = evt.pc;
+    let step = {
+      opcodeName: evt.opcode.name,
+      input: {
+        data: data,
+        stack: _stack,
+        compactStack: evt.opcode.in ? _stack.slice(-evt.opcode.in) : (stackFixed || []),
+        mem: _mem,
+        returnData: '',
+        pc: pc,
+        gasRemaining: evt.gasLeft.toNumber(),
+      },
+      output: {
+        data: data,
+        compactStack: new Array(evt.opcode.out),
+        mem: '',
+        returnData: '',
+        pc: pc,
+        errno: 0,
+        gasRemaining: 0,
+      },
+      code: code,
+      isCallDataRequired: isCallDataRequired,
+      isMemoryRequired: isMemoryRequired,
+    };
+
+    let prevStep = context.steps[context.steps.push(step) - 2];
+    if (prevStep) {
+      let isFullCodeNeeded = CODE_OPCODES.indexOf(prevStep.opcodeName) !== -1;
+      if (isFullCodeNeeded) {
+        prevStep.input.code = code;
+        prevStep.input.isCodeCompacted = false;
+      } else {
+        prevStep.input.code = code.slice(context.pc, pc);
+        prevStep.input.isCodeCompacted = true;
+      }
+
+      if (prevStep.output.compactStack.length) {
+        prevStep.output.compactStack = _stack.slice(-prevStep.output.compactStack.length);
+      }
+
+      prevStep.output.mem = _mem;
+      prevStep.output.pc = pc;
+      prevStep.output.gasRemaining = evt.gasLeft.toNumber();
+      prevStep.gasFee = context.gasLeft.sub(evt.gasLeft).toNumber();
+      prevStep.output.stack = _stack;
+    }
+    context.pc = pc;
+    context.gasLeft = evt.gasLeft;
+  }
+
+  static async run ({ code, data, stack, mem, accounts, logHash, gasLimit, blockGasLimit, gasRemaining, pc }) {
+    data = data ? data.replace('0x', '') : '';
+    blockGasLimit = Buffer.from(
+      (blockGasLimit || OP.BLOCK_GAS_LIMIT).toString(16).replace('0x', ''),
+      'hex'
+    );
+
+    const evm = new VM();
+
+    if (accounts) {
+      await this.initAccounts(evm, accounts);
+    }
+
+    const context = {
+      pc: pc | 0,
+      steps: [],
+      gasLeft: null,
+      inject: true,
+    };
+
+    evm.on('step', (evt) => this._onStep(evt, context, code, data, stack, mem, gasRemaining));
+
+    const defaultBlock = {
+      header: {
+        gasLimit: blockGasLimit,
+        number: Buffer.from('00', 'hex'),
+      },
+    };
+
+    const steps = await new Promise((resolve, reject) => {
+      evm.runCode(
+        {
+          code: Buffer.from(code.join(''), 'hex'),
+          data: Buffer.from(data, 'hex'),
+          gasLimit: Buffer.from(
+            (gasLimit || OP.BLOCK_GAS_LIMIT).toString(16).replace('0x', ''),
+            'hex'
+          ),
+          gasPrice: 0,
+          caller: DEFAULT_CALLER,
+          origin: DEFAULT_CALLER,
+          address: DEFAULT_CONTRACT_ADDRESS,
+          block: defaultBlock,
+          pc: context.pc,
+        },
+        (err, res) => {
+          if (err) {
+            // we handle execution errors further below
+          }
+
+          let prevStep = context.steps[context.steps.length - 1];
+          if (prevStep) {
+            let _stack = toHex(res.runState.stack);
+            let isFullCodeNeeded = CODE_OPCODES.indexOf(prevStep.opcodeName) !== -1;
+
+            if (isFullCodeNeeded) {
+              prevStep.input.code = code;
+              prevStep.input.isCodeCompacted = false;
+            } else {
+              prevStep.input.code = code.slice(context.pc, res.runState.programCounter);
+              prevStep.input.isCodeCompacted = true;
+            }
+
+            if (prevStep.output.compactStack.length) {
+              prevStep.output.compactStack = _stack.slice(-prevStep.output.compactStack.length);
+            }
+
+            prevStep.output.mem = Buffer.from(res.runState.memory).toString('hex');
+            prevStep.output.returnData = res.return.toString('hex');
+            prevStep.output.stack = _stack;
+
+            let errno = 0;
+            if (res.exceptionError) {
+              // ethereumvm-js is appending the location for jumps ;)
+              const errorKeysLength = ERROR_KEYS.length;
+              const errMsg = res.exceptionError.error
+                ? res.exceptionError.error : res.exceptionError;
+
+              for (let i = 0; i < errorKeysLength; i++) {
+                const k = ERROR_KEYS[i];
+
+                if (errMsg.startsWith(k)) {
+                  errno = ERRNO_MAP[k];
+                  break;
+                }
+              }
+            }
+            prevStep.output.errno = errno;
+
+            if (prevStep.output.errno === 0 && prevStep.opcodeName !== 'RETURN') {
+              prevStep.output.pc = res.runState.programCounter;
+            }
+
+            prevStep.output.gasRemaining = res.runState.gasLeft.toNumber();
+            prevStep.gasFee = context.gasLeft.sub(res.runState.gasLeft).toNumber();
+          }
+
+          let len = context.steps.length;
+          let prevLogHash = logHash ? logHash.replace('0x', '') : ZERO_HASH;
+          for (let i = 0; i < len; i++) {
+            const step = context.steps[i];
+
+            step.input.logHash = prevLogHash;
+
+            if (step.opcodeName.startsWith('LOG')) {
+              let log = res.logs.pop();
+
+              if (!log) {
+                throw new Error('step with LOGx opcode but no log emitted');
+              }
+              step.log = log;
+
+              let topics = log[1];
+              while (topics.length !== 4) {
+                topics.push(0);
+              }
+              let hash = ethers.utils.solidityKeccak256(
+                ['bytes32', 'address', 'uint[4]', 'bytes'],
+                [
+                  '0x' + prevLogHash,
+                  '0x' + log[0].toString('hex'),
+                  topics,
+                  '0x' + log[2].toString('hex'),
+                ]
+              ).replace('0x', '');
+
+              step.output.logHash = hash;
+              prevLogHash = hash;
+              continue;
+            }
+
+            step.output.logHash = prevLogHash;
+          }
+
+          resolve(context.steps);
+        }
+      );
+    });
+
+    let i = steps.length;
+    while (i--) {
+      steps[i].accounts = await this.dumpTouchedAccounts(evm);
+
+      await new Promise(
+        (resolve, reject) => {
+          evm.stateManager.revert(
+            () => {
+              resolve(true);
+            }
+          );
+        }
+      );
+    }
+
+    return steps;
+  }
+}


### PR DESCRIPTION
- Implements a `OffchainStepper` via ethereumjs-vm.
- Landing an initial Dispute logic in JS, with compact stack, semi-compact-{callData, memory} 🤣 

Notes:
  The JS DisputeMock functionality is going to be implemented in solidity in a separate PR.
  I'm going to document the dispute logic in a separate markdown doc, after we finalize it 😄 

Related #20 #21