### PR TITLE
fixed EVMMemory tests

### DIFF
--- a/test/TestEVMMemory.sol
+++ b/test/TestEVMMemory.sol
@@ -25,7 +25,7 @@ contract TestEVMMemory {
         Assert.equal(mem.cap, ALLOC_SIZE, "mem.cap");
 
         uint fMem = MemOps.freeMemPtr();
-        Assert.equal(mem.dataPtr + mem.cap*WORD_SIZE, fMem, "freeMemPtr");
+        Assert.equal(mem.dataPtr + mem.cap*WORD_SIZE + 64, fMem, "freeMemPtr");
 
         for(uint i = 0; i < ALLOC_SIZE; i++) {
             uint pos = mem.dataPtr + i*WORD_SIZE;
@@ -46,7 +46,7 @@ contract TestEVMMemory {
         Assert.equal(mem.cap, 128, "memory capacity");
 
         uint fMem = MemOps.freeMemPtr();
-        Assert.equal(mem.dataPtr + mem.cap*WORD_SIZE, fMem, "free memory pointer");
+        Assert.equal(mem.dataPtr + mem.cap*WORD_SIZE + 64, fMem, "free memory pointer");
 
         for(uint i = 0; i < 128; i++) {
             uint pos = mem.dataPtr + i*WORD_SIZE;
@@ -204,7 +204,7 @@ contract TestEVMMemory {
         Assert.equal(mem.size, 1513, "");
         Assert.equal(mem.cap, 2048, "");
         uint fMem = MemOps.freeMemPtr();
-        Assert.equal(mem.dataPtr + mem.cap*WORD_SIZE, fMem, "free memory pointer");
+        Assert.equal(mem.dataPtr + mem.cap*WORD_SIZE + 64, fMem, "free memory pointer");
     }
 
     function getRootHash() public view returns (uint) {


### PR DESCRIPTION
### EVMMemory tests

Previously, 3 tests within `TestEVMMemory.sol` were failing. All 3 used truffle's `Assert` library to verify that the free Memory pointer pointed to the next empty memory space after running some of solEVM's memory allocation functions. 

It turns out that every time we use `Assert.equal()`, another word from library's native variables is added to the memory.

I updated the assert statements to account for these extra words.

