### PR TITLE
Fix "execute till code position" logic.

### DIFF
--- a/contracts/EthereumRuntime.sol
+++ b/contracts/EthereumRuntime.sol
@@ -368,15 +368,12 @@ contract EthereumRuntime is EVMConstants {
         uint pcNext = 0;
         uint errno = NO_ERROR;
         bytes memory code = evm.code;
-        if (pcEnd == 0) {
-            pcEnd = code.length;
-        }
 
         if (evm.gas > evm.context.gasLimit) {
             errno = ERROR_OUT_OF_GAS;
         }
 
-        while (errno == NO_ERROR && pc < code.length && pc != pcEnd) {
+        while (errno == NO_ERROR && pc < code.length && (pcEnd == 0 || pc != pcEnd)) {
             uint opcode = uint(code[pc]);
             Instruction memory ins = evm.handlers.ins[opcode];
 

--- a/contracts/EthereumRuntime.sol
+++ b/contracts/EthereumRuntime.sol
@@ -376,7 +376,7 @@ contract EthereumRuntime is EVMConstants {
             errno = ERROR_OUT_OF_GAS;
         }
 
-        while (errno == NO_ERROR && pc < pcEnd) {
+        while (errno == NO_ERROR && pc < code.length && pc != pcEnd) {
             uint opcode = uint(code[pc]);
             Instruction memory ins = evm.handlers.ins[opcode];
 


### PR DESCRIPTION
If we specify `pcEnd`, we want execution to stop on this particular codepoint, not just on any codepoint after `pcEnd`.
While the latter worked for linear programs or programs with backward jumps only, it breaks if jump is made to the codepoint after `pcEnd`.

Resolves #27

- [x] fix jumps
- [x] fix "execute till the end" logic