### PR TITLE
Use ExecutionPoker for dispute fixtures

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,6 +1,6 @@
 module.exports = {
   compileCommand: '../node_modules/.bin/truffle compile',
-  testCommand: 'COVERAGE=1 ../node_modules/.bin/truffle test --network coverage test/contracts/*',
+  testCommand: 'COVERAGE=1 ../node_modules/.bin/mocha --timeout 120000 test/contracts/*',
   norpc: true,
   deepSkip: true,
   skipFiles: ['mocks/', 'PlasmaVerifier.sol'],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "utils/index.js",
   "scripts": {
     "test": "yarn test:contracts && yarn test:utils",
-    "test:contracts": "scripts/test.sh test/contracts/*",
+    "test:contracts": "yarn compile:contracts && scripts/test.sh test/contracts/*",
     "test:utils": "mocha test/utils/",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "ethereumjs-vm": "https://github.com/pinkiebell/ethereumjs-vm.git#release/v2.6.0-r5",
-    "ethers": "^4.0.13",
+    "ethers": "^4.0.32",
     "openzeppelin-solidity": "=2.1.1"
   }
 }

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -14,8 +14,8 @@ accounts=(
   --account="0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501209,1000000000000000000000000"
 )
 
-./node_modules/.bin/testrpc-sc --hardfork petersburg --allowUnlimitedContractSize -p 8555 -g 0x01 -l 0xfffffffffffff "${accounts[@]}" > /dev/null &
+./node_modules/.bin/testrpc-sc --hardfork petersburg --allowUnlimitedContractSize -p 8333 -g 0x01 -l 0xfffffffffffff "${accounts[@]}" > /dev/null &
 pid=$!
-./node_modules/.bin/solidity-coverage
+RPC_PORT=8333 ./node_modules/.bin/solidity-coverage
 kill $pid
 exit 0

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,7 +13,7 @@ cleanup() {
   fi
 }
 
-ganache_port=8545
+ganache_port=8111
 
 ganache_running() {
   nc -z localhost "$ganache_port"
@@ -44,6 +44,7 @@ if ganache_running; then
 else
   echo "Starting our own ganache instance"
   start_ganache
+  sleep 3
 fi
 
 if [ "$SOLC_NIGHTLY" = true ]; then
@@ -51,4 +52,4 @@ if [ "$SOLC_NIGHTLY" = true ]; then
   wget -q https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/soljson-nightly.js -O /tmp/soljson.js && find . -name soljson.js -exec cp /tmp/soljson.js {} \;
 fi
 
-yarn truffle test "$@"
+RPC_PORT=$ganache_port yarn mocha --timeout 60000 "$@"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,16 +3,6 @@
 # Exit script as soon as a command fails.
 set -o errexit
 
-# Executes cleanup function at script exit.
-trap cleanup EXIT
-
-cleanup() {
-  # Kill the ganache instance that we started (if we started one and if it's still running).
-  if [ -n "$ganache_pid" ] && ps -p $ganache_pid > /dev/null; then
-    kill -9 $ganache_pid
-  fi
-}
-
 ganache_port=8111
 
 ganache_running() {

--- a/scripts/test_geth.sh
+++ b/scripts/test_geth.sh
@@ -3,16 +3,6 @@
 # Exit script as soon as a command fails.
 set -o errexit
 
-# Executes cleanup function at script exit.
-trap cleanup EXIT
-
-cleanup() {
-  # Kill the geth instance that we started (if we started one and if it's still running).
-  if [ -n "$geth_pid" ] && ps -p $geth_pid > /dev/null; then
-    kill -9 $geth_pid
-  fi
-}
-
 geth_port=8222
 geth=$(which geth)
 

--- a/scripts/test_geth.sh
+++ b/scripts/test_geth.sh
@@ -13,7 +13,7 @@ cleanup() {
   fi
 }
 
-geth_port=8545
+geth_port=8222
 geth=$(which geth)
 
 geth_running() {
@@ -57,5 +57,4 @@ else
   start_geth
 fi
 
-echo 'running truffle'
-yarn truffle test "$@"
+RPC_PORT=$geth_port yarn mocha --timeout 60000 "$@"

--- a/test/contracts/PlasmaVerifier.js
+++ b/test/contracts/PlasmaVerifier.js
@@ -1,10 +1,10 @@
 
 const { wallets, deployContract, txOverrides, opcodeNames } = require('./../helpers/utils');
 
-const SpendingConditionMock = artifacts.require('SpendingConditionMock.sol');
-const Interceptor = artifacts.require('PlasmaVerifier.sol');
+const SpendingConditionMock = require('./../../build/contracts/SpendingConditionMock.json');
+const Interceptor = require('./../../build/contracts/PlasmaVerifier.json');
 
-contract('PlasmaVerifier', () => {
+describe('PlasmaVerifier', () => {
   // skip test if we do coverage
   if (process.env.COVERAGE) {
     return;

--- a/test/contracts/dispute.js
+++ b/test/contracts/dispute.js
@@ -1,0 +1,171 @@
+const ethers = require('ethers');
+const debug = require('debug')('vgame-test');
+const assert = require('assert');
+
+const { Merkelizer, ExecutionPoker, Constants } = require('./../../utils');
+const disputeFixtures = require('./../fixtures/dispute');
+const { onchainWait, deployContract, deployCode, wallets, provider } = require('./../helpers/utils');
+
+const Verifier = require('./../../build/contracts/Verifier.json');
+const Enforcer = require('./../../build/contracts/Enforcer.json');
+
+const SOLVER_VERIFIED = (1 << 2);
+
+const EVMParameters = {
+  origin: '0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1',
+  target: '0xfeefeefeefeefeefeefeefeefeefeefeefeefee0',
+  blockHash: '0xdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdc',
+  blockNumber: 123,
+  time: 1560775755,
+  txGasLimit: 0xffffffffff,
+  customEnvironmentHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  dataHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+};
+
+class MyExecutionPoker extends ExecutionPoker {
+  async submitRound (disputeId) {
+    try {
+      await super.submitRound(disputeId);
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  async submitProof (disputeId, computationPath) {
+    try {
+      await super.submitProof(disputeId, computationPath);
+    } catch (e) {
+      // ignore
+    }
+
+    this.afterSubmitProof(disputeId);
+  }
+
+  async computeCall (evmParams, invalidateLastStep) {
+    return { steps: this._steps, merkle: this._merkle };
+  }
+
+  async requestExecution (contractAddr, callData) {
+    const codeHash = `0x${contractAddr.replace('0x', '').toLowerCase().padEnd(64, '0')}`;
+    const dataHash = Merkelizer.dataHash(callData);
+    const evmParams = Object.assign(EVMParameters, { codeHash, dataHash });
+
+    return super.requestExecution(evmParams, callData);
+  }
+
+  log (...args) {
+    debug(...args);
+  }
+}
+
+describe('Verifier', function () {
+  let enforcer;
+  let verifier;
+  let execPokerSolver;
+  let execPokerChallenger;
+
+  before(async () => {
+    const taskPeriod = 1000000;
+    const challengePeriod = 1000;
+    const timeoutDuration = 10;
+    const bondAmount = 1;
+    const maxExecutionDepth = 10;
+
+    verifier = await deployContract(Verifier, timeoutDuration);
+    enforcer = await deployContract(
+      Enforcer, verifier.address, taskPeriod, challengePeriod, bondAmount, maxExecutionDepth
+    );
+
+    let tx = await verifier.setEnforcer(enforcer.address);
+
+    await tx.wait();
+
+    // yes, we need a new provider. Otherwise we get duplicate events...
+    const solverWallet = wallets[2].connect(new ethers.providers.JsonRpcProvider(provider.connection.url));
+    const challengerWallet = wallets[3].connect(new ethers.providers.JsonRpcProvider(provider.connection.url));
+    // let's be faster (events)
+    solverWallet.provider.pollingInterval = 30;
+    challengerWallet.provider.pollingInterval = 30;
+
+    execPokerSolver = new MyExecutionPoker(
+      enforcer,
+      verifier,
+      solverWallet,
+      Constants.GAS_LIMIT,
+      'solver'
+    );
+    after(function (done) {
+      done();
+      process.exit(0);
+    });
+
+    execPokerChallenger = new MyExecutionPoker(
+      enforcer,
+      verifier,
+      challengerWallet,
+      Constants.GAS_LIMIT,
+      'challenger'
+    );
+    execPokerChallenger.alwaysChallenge = true;
+  });
+
+  disputeFixtures(
+    async (code, callData, solverMerkle, challengerMerkle, expectedWinner) => {
+      // use merkle tree from fixture
+      execPokerSolver._merkle = solverMerkle;
+      execPokerSolver._steps = [];
+      execPokerChallenger._merkle = challengerMerkle;
+      execPokerChallenger._steps = [];
+
+      const codeContract = await deployCode(code);
+      const winner = await new Promise(
+        (resolve, reject) => {
+          let resolved = false;
+          let state = 0;
+
+          async function decide (disputeId) {
+            state++;
+            if (state !== 2) {
+              return;
+            }
+
+            const dispute = await verifier.disputes(disputeId);
+            let winner = 'challenger';
+            if ((dispute.state & SOLVER_VERIFIED) !== 0) {
+              winner = 'solver';
+            }
+            if (!resolved) {
+              resolved = true;
+              resolve(winner);
+            }
+          }
+
+          execPokerSolver.afterSubmitProof = async (disputeId) => {
+            decide(disputeId);
+          };
+          execPokerChallenger.afterSubmitProof = async (disputeId) => {
+            decide(disputeId);
+          };
+          execPokerSolver.onSlashed = () => {
+            if (!resolved) {
+              resolved = true;
+              resolve('challenger');
+            }
+          };
+          execPokerChallenger.onSlashed = () => {
+            if (!resolved) {
+              resolved = true;
+              resolve('solver');
+            }
+          };
+
+          execPokerSolver.requestExecution(codeContract.address, callData);
+        }
+      );
+
+      assert.equal(winner, expectedWinner, 'winner should match fixture');
+      await onchainWait(10);
+    }
+  );
+});

--- a/test/contracts/enforcer.js
+++ b/test/contracts/enforcer.js
@@ -1,14 +1,16 @@
 const ethers = require('ethers');
+const assert = require('assert');
+
 const { onchainWait, toBytes32, wallets, deployContract, txOverrides } = require('./../helpers/utils');
 const assertRevert = require('./../helpers/assertRevert');
 
-const Enforcer = artifacts.require('./Enforcer.sol');
-const Verifier = artifacts.require('./Verifier.sol');
-const VerifierMock = artifacts.require('./mocks/VerifierMock.sol');
+const Enforcer = require('./../../build/contracts/Enforcer.json');
+const Verifier = require('./../../build/contracts/Verifier.json');
+const VerifierMock = require('./../../build/contracts/VerifierMock.json');
 
 const GAS_LIMIT = require('./../../utils/constants').GAS_LIMIT;
 
-contract('Enforcer', () => {
+describe('Enforcer', () => {
   const solverPathRoot = '0x712bc4532b751c4417b44cf11e2377778433ff720264dc8a47cb1da69d371433';
   const challengerPathRoot = '0x641db1239a480d87bdb76fc045d5f6a68ad1cbf9b93e3b2c92ea638cff6c2add';
   const result = '0x0000000000000000000000000000000000000000000000000000000000001111';
@@ -138,7 +140,7 @@ contract('Enforcer', () => {
 
     const execution = await enforcer.executions(executionId);
 
-    assert.isTrue(execution.startBlock.gt(0), 'start block not set');
+    assert.ok(execution.startBlock.gt(0), 'start block not set');
     assert.equal(execution.solverPathRoot, solverPathRoot, 'solverPathRoot not match');
     assert.equal(execution.executionDepth, executionDepth, 'execution length not match');
     assert.equal(execution.solver, solver.address, 'solver address not match');
@@ -240,7 +242,7 @@ contract('Enforcer', () => {
 
     tx = verifierMock.submitResult(executionId, false, challenger.address, { gasLimit: GAS_LIMIT });
     await assertRevert(tx, 'Execution is out of challenge period');
-  });
+  }).timeout(10000);
 
   it('allow submit result of valid execution and slash solver', async () => {
     const _solverPathRoot = solverPathRoot.replace('11', '55');

--- a/test/contracts/ethereumRuntime.js
+++ b/test/contracts/ethereumRuntime.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const assert = require('assert');
 
 const { getCode, deployContract, deployCode } =
   require('./../helpers/utils');
@@ -9,9 +10,9 @@ const OP = require('./../../utils/constants');
 
 const { PUSH1, BLOCK_GAS_LIMIT } = OP;
 
-const EthereumRuntime = artifacts.require('EthereumRuntime.sol');
+const EthereumRuntime = require('./../../build/contracts/EthereumRuntime.json');
 
-contract('Runtime', function () {
+describe('Runtime', function () {
   let rt;
 
   before(async () => {

--- a/test/contracts/evmCode.test.js
+++ b/test/contracts/evmCode.test.js
@@ -1,9 +1,9 @@
 const { deployContract } = require('./../helpers/utils');
 const BN = require('ethers').utils.BigNumber;
-const EVMCodeMock = artifacts.require('EVMCodeMock.sol');
+const EVMCodeMock = require('./../../build/contracts/EVMCodeMock.json');
 const assert = require('assert');
 
-contract('TestEVMCode', function () {
+describe('TestEVMCode', function () {
   let evmCode;
 
   before(async () => {

--- a/test/contracts/evmStack.test.js
+++ b/test/contracts/evmStack.test.js
@@ -1,10 +1,10 @@
 
 const { deployContract } = require('./../helpers/utils');
 
-const EVMStackMock = artifacts.require('EVMStackMock.sol');
+const EVMStackMock = require('./../../build/contracts/EVMStackMock.json');
 const assert = require('assert');
 
-contract('TestEVMStack', function () {
+describe('TestEVMStack', function () {
   let stack;
 
   before(async () => {

--- a/test/contracts/onChain.test.js
+++ b/test/contracts/onChain.test.js
@@ -1,11 +1,13 @@
+const assert = require('assert');
+
 const { getCodeWithStep, deployContract, deployCode, toBN } = require('./../helpers/utils');
 const onChainFixtures = require('./../fixtures/onChain');
 const Runtime = require('./../../utils/EthereumRuntimeAdapter');
 
 const OP = require('./../../utils/constants');
-const EthereumRuntime = artifacts.require('EthereumRuntime.sol');
+const EthereumRuntime = require('./../../build/contracts/EthereumRuntime.json');
 
-contract('Runtime', function () {
+describe('Runtime', function () {
   let rt;
 
   before(async () => {

--- a/test/contracts/testMemOps.js
+++ b/test/contracts/testMemOps.js
@@ -1,8 +1,8 @@
 const { deployContract } = require('./../helpers/utils');
 
-const TestMemOps = artifacts.require('TestMemOps.sol');
+const TestMemOps = require('./../../build/contracts/TestMemOps.json');
 
-contract('TestMemOps', function () {
+describe('TestMemOps', function () {
   let contract;
 
   before(async () => {

--- a/test/contracts/verifier.js
+++ b/test/contracts/verifier.js
@@ -1,14 +1,13 @@
+const assert = require('assert');
+
 const Merkelizer = require('./../../utils/Merkelizer');
-const ProofHelper = require('./../../utils/ProofHelper');
-const disputeFixtures = require('./../fixtures/dispute');
 const { onchainWait, toBytes32, deployContract, txOverrides, deployCode } = require('./../helpers/utils');
 const OP = require('./../../utils/constants');
 const assertRevert = require('./../helpers/assertRevert');
-const debug = require('debug')('vgame-test');
 const GAS_LIMIT = OP.GAS_LIMIT;
 
-const Verifier = artifacts.require('Verifier.sol');
-const Enforcer = artifacts.require('Enforcer.sol');
+const Verifier = require('./../../build/contracts/Verifier.json');
+const Enforcer = require('./../../build/contracts/Enforcer.json');
 
 const ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000';
 const ONE_HASH = '0x0000000000000000000000000000000000000000000000000000000000000001';
@@ -16,8 +15,6 @@ const TWO_HASH = '0x000000000000000000000000000000000000000000000000000000000000
 const ZERO_WITNESS_PATH = { left: ZERO_HASH, right: ZERO_HASH };
 const SOLVER_VERIFIED = (1 << 2);
 const CHALLENGER_VERIFIED = (1 << 3);
-
-// TODO: we should use the ExecutionPoker class to execute the fixtures in the future :)
 const EVMParameters = {
   origin: '0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1',
   target: '0xfeefeefeefeefeefeefeefeefeefeefeefeefee0',
@@ -44,216 +41,7 @@ async function requestExecution (enforcer, code, callData) {
   return { taskHash, params };
 }
 
-function computeWitnessPath (dispute, merkleTree) {
-  const needsWitness = dispute.witness !== ZERO_HASH;
-
-  if (needsWitness) {
-    const path = merkleTree.getNode(dispute.witness);
-
-    return { left: path.left.hash, right: path.right.hash };
-  }
-
-  return ZERO_WITNESS_PATH;
-}
-
-async function submitProofHelper (verifier, disputeId, code, computationPath) {
-  const args = ProofHelper.constructProof(computationPath);
-
-  let tx = await verifier.submitProof(
-    disputeId,
-    args.proofs,
-    args.executionInput,
-    txOverrides
-  );
-
-  tx = await tx.wait();
-
-  /*
-  tx.events.forEach(
-    (ele) => {
-      console.log(ele.args);
-    }
-  );
-  */
-
-  return tx;
-}
-
-async function disputeGame (
-  enforcer, verifier, codeContract, code, callData, solverMerkle, challengerMerkle, expectedWinner, expectedError
-) {
-  let disputeId;
-
-  try {
-    let solverComputationPath = solverMerkle.root;
-    let challengerComputationPath = challengerMerkle.root;
-
-    // TODO: handle the bigger case too
-    if (solverMerkle.depth < challengerMerkle.depth) {
-      challengerComputationPath = challengerMerkle.tree[solverMerkle.depth - 1][0];
-    }
-
-    const bondAmount = await enforcer.bondAmount();
-    const { taskHash, params } = await requestExecution(enforcer, code, callData);
-
-    let tx = await enforcer.register(
-      taskHash,
-      solverComputationPath.hash,
-      new Array(solverMerkle.depth).fill(ZERO_HASH),
-      ZERO_HASH,
-      { value: bondAmount, gasPrice: 0x01, gasLimit: GAS_LIMIT }
-    );
-    tx = await tx.wait();
-
-    tx = await enforcer.dispute(
-      solverComputationPath.hash,
-      challengerComputationPath.hash,
-      params,
-      { value: bondAmount, gasPrice: 0x01, gasLimit: GAS_LIMIT }
-    );
-
-    let dispute = await tx.wait();
-    let event = dispute.events[0].args;
-
-    disputeId = event.disputeId;
-
-    while (true) {
-      dispute = await verifier.disputes(event.disputeId);
-
-      if (solverComputationPath.isLeaf && challengerComputationPath.isLeaf) {
-        debug('REACHED leaves');
-
-        debug('Solver: SUBMITTING FOR l=' +
-          solverComputationPath.left.hash + ' r=' + solverComputationPath.right.hash);
-        await submitProofHelper(verifier, event.disputeId, code, solverComputationPath);
-
-        // refresh
-        dispute = await verifier.disputes(event.disputeId);
-        if ((dispute.state & SOLVER_VERIFIED === 0) && (dispute.state & CHALLENGER_VERIFIED === 0)) {
-          debug('Challenger: SUBMITTING FOR l=' +
-          challengerComputationPath.left.hash + ' r=' + challengerComputationPath.right.hash);
-          await submitProofHelper(verifier, event.disputeId, code, challengerComputationPath);
-        }
-
-        // refresh again
-        dispute = await verifier.disputes(event.disputeId);
-
-        let winner = 'challenger';
-        if ((dispute.state & SOLVER_VERIFIED) !== 0) {
-          winner = 'solver';
-        }
-        debug('winner=' + winner);
-
-        assert.equal(winner, expectedWinner, 'winner should match fixture');
-        break;
-      }
-
-      if (!solverComputationPath.isLeaf) {
-        let solverPath = dispute.solverPath;
-        let nextPath = solverMerkle.getNode(solverPath);
-
-        if (!nextPath) {
-          debug('solver: submission already made by another party');
-          solverComputationPath = solverMerkle.getPair(dispute.solver.left, dispute.solver.right);
-          continue;
-        }
-
-        if (solverComputationPath.left.hash === solverPath) {
-          debug('solver goes left from ' +
-            solverComputationPath.hash.substring(2, 6) + ' to ' +
-            solverComputationPath.left.hash.substring(2, 6)
-          );
-        } else if (solverComputationPath.right.hash === solverPath) {
-          debug('solver goes right from ' +
-            solverComputationPath.hash.substring(2, 6) + ' to ' +
-            solverComputationPath.right.hash.substring(2, 6)
-          );
-        }
-
-        solverComputationPath = nextPath;
-
-        const witnessPath = computeWitnessPath(dispute, solverMerkle);
-
-        debug('Solver respond\n',
-          `\tleft = ${solverComputationPath.left.hash}`,
-          `\tright = ${solverComputationPath.right.hash}`,
-          `\twitnessPath = l=${witnessPath.left} r=${witnessPath.right}`);
-        tx = await verifier.respond(
-          event.disputeId,
-          {
-            left: solverComputationPath.left.hash,
-            right: solverComputationPath.right.hash,
-          },
-          witnessPath,
-          txOverrides
-        );
-        await tx.wait();
-        dispute = await verifier.disputes(event.disputeId);
-      }
-
-      if (!challengerComputationPath.isLeaf) {
-        let challengerPath = dispute.challengerPath;
-        let nextPath = challengerMerkle.getNode(challengerPath);
-
-        if (!nextPath) {
-          debug('challenger submission already made by another party');
-          challengerComputationPath =
-            challengerMerkle.getPair(dispute.challenger.left, dispute.challenger.right);
-          continue;
-        }
-
-        if (challengerComputationPath.left.hash === challengerPath) {
-          debug('challenger goes left from ' +
-            challengerComputationPath.hash.substring(2, 6) + ' to ' +
-            challengerComputationPath.left.hash.substring(2, 6)
-          );
-        } else if (challengerComputationPath.right.hash === challengerPath) {
-          debug('challenger goes right from ' +
-            challengerComputationPath.hash.substring(2, 6) + ' to ' +
-            challengerComputationPath.right.hash.substring(2, 6)
-          );
-        }
-
-        challengerComputationPath = nextPath;
-
-        const witnessPath = computeWitnessPath(dispute, challengerMerkle);
-
-        debug('Challenger respond\n',
-          `\tleft = ${challengerComputationPath.left.hash}`,
-          `\tright = ${challengerComputationPath.right.hash}`,
-          `\twitnessPath = l=${witnessPath.left} r=${witnessPath.right}`);
-        tx = await verifier.respond(
-          event.disputeId,
-          {
-            left: challengerComputationPath.left.hash,
-            right: challengerComputationPath.right.hash,
-          },
-          witnessPath,
-          txOverrides
-        );
-        await tx.wait();
-      }
-    }
-  } catch (e) {
-    if (expectedError) {
-      assert.equal(e.message, expectedError);
-      return;
-    }
-
-    // refresh again
-    const dispute = await verifier.disputes(disputeId);
-
-    let winner = 'challenger';
-    if ((dispute.state & SOLVER_VERIFIED) !== 0) {
-      winner = 'solver';
-    }
-    debug('winner=' + winner);
-
-    assert.equal(winner, expectedWinner, 'winner should match fixture');
-  }
-}
-
-contract('Verifier', function () {
+describe('Verifier', function () {
   let enforcer;
   let verifier;
 
@@ -273,23 +61,6 @@ contract('Verifier', function () {
 
     await tx.wait();
   });
-
-  disputeFixtures(
-    async (code, callData, solverMerkle, challengerMerkle, expectedWinner) => {
-      const codeContract = await deployCode(code);
-
-      await disputeGame(
-        enforcer,
-        verifier,
-        codeContract.address,
-        code,
-        callData,
-        solverMerkle,
-        challengerMerkle,
-        expectedWinner
-      );
-    }
-  );
 
   describe('submitProof', async () => {
     it('not allow preemptive submission of proof', async () => {
@@ -423,8 +194,6 @@ contract('Verifier', function () {
 
       let dispute = await verifier.disputes(disputeId);
       // TODO may add dispute result directly to Verifier?
-      const SOLVER_VERIFIED = 1 << 2;
-
       assert.notEqual(dispute.state & SOLVER_VERIFIED, 0, 'solver should win');
 
       // cannot call claimTimeout a second time
@@ -477,9 +246,6 @@ contract('Verifier', function () {
       tx = await tx.wait();
 
       let dispute = await verifier.disputes(disputeId);
-      // TODO may add dispute result directly to Verifier?
-      const SOLVER_VERIFIED = 1 << 2;
-
       assert.notEqual(dispute.state & SOLVER_VERIFIED, 0, 'solver should win');
     });
 

--- a/test/fixtures/dispute.js
+++ b/test/fixtures/dispute.js
@@ -425,6 +425,8 @@ module.exports = (callback) => {
   });
 
   describe('Fixture for Dispute/Verifier Logic #4', function () {
+    this.timeout(55550);
+
     const code = [
       OP.PUSH3, 'a1a1a1',
       OP.PUSH3, 'ffffff',

--- a/test/helpers/assertRevert.js
+++ b/test/helpers/assertRevert.js
@@ -1,3 +1,6 @@
+const assert = require('assert');
+const Utils = require('./utils');
+
 module.exports = async (promise, message) => {
   try {
     let tx = await promise;
@@ -7,7 +10,7 @@ module.exports = async (promise, message) => {
     // support for the unspecific error 'transaction failed' of geth
     const revertFound = error.message.search(/(revert|transaction failed|always failing transaction)/) >= 0;
     assert(revertFound, `Expected "revert", got ${error} instead`);
-    const client = await web3.eth.getNodeInfo();
+    const client = await Utils.client();
     // Geth does not return full error message
     if (message && !client.startsWith('Geth')) {
       const messageFound = error.message.search(message) >= 0;

--- a/tools/executionPoker.js
+++ b/tools/executionPoker.js
@@ -33,6 +33,14 @@ class MyExecutionPoker extends ExecutionPoker {
 
     return super.requestExecution(evmParams, callData);
   }
+
+  async submitProof (disputeId, computationPath) {
+    try {
+      await super.submitProof(disputeId, computationPath);
+    } catch (e) {
+      // ignore for unit test
+    }
+  }
 }
 
 async function deployContract (truffleContract, wallet, ...args) {
@@ -87,6 +95,10 @@ async function main () {
   deployerWallet = deployerWallet.connect(new ethers.providers.Web3Provider(provider));
   solverWallet = solverWallet.connect(new ethers.providers.Web3Provider(provider));
   challengerWallet = challengerWallet.connect(new ethers.providers.Web3Provider(provider));
+
+  // faster unit tests :)
+  solverWallet.provider.pollingInterval = 30;
+  challengerWallet.provider.pollingInterval = 30;
 
   const timeout = 10;
   const taskPeriod = 100000;

--- a/yarn.lock
+++ b/yarn.lock
@@ -938,10 +938,10 @@ ethereumjs-util@^6.0.0:
     rustbn.js "~0.2.0"
     safe-buffer "^5.1.1"
 
-ethers@^4.0.13:
-  version "4.0.27"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.27.tgz#e570b0da9d805ad65c83d81919abe02b2264c6bf"
-  integrity sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==
+ethers@^4.0.32:
+  version "4.0.32"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.32.tgz#46378864cb3bf29b57c2effd17508b560743abf6"
+  integrity sha512-r0k2tBNF6MYEsvwmINeP3VPppD/7eAZyiOk/ifDDawXGCKqr3iEQkPq6OZSDVD+4Jie38WPteS9thXzpn2+A5Q==
   dependencies:
     "@types/node" "^10.3.2"
     aes-js "3.0.0"


### PR DESCRIPTION
-  Use ExecutionPoker for dispute fixtures 
- Use just mocha instead of truffle test
- set pollingTime on rpc provider to gain faster event handling

Fixes #146 