### PR TITLE
pass-down customEnvironmentHash

### DIFF
--- a/tools/executionPoker.js
+++ b/tools/executionPoker.js
@@ -51,7 +51,13 @@ class MyExecutionPoker extends ExecutionPoker {
 
       const leaf = res.merkle.leaves[0];
       leaf.right.executionState.gasRemaining = 2222;
-      leaf.right.hash = Merkelizer.stateHash(leaf.right.executionState, leaf.right.stackHash, leaf.right.memHash);
+      leaf.right.hash = Merkelizer.stateHash(
+        leaf.right.executionState,
+        leaf.right.stackHash,
+        leaf.right.memHash,
+        evmParams.dataHash,
+        evmParams.customEnvironmentHash
+      );
       leaf.hash = Merkelizer.hash(leaf.left.hash, leaf.right.hash);
       res.merkle.recal(0);
     }

--- a/utils/ExecutionPoker.js
+++ b/utils/ExecutionPoker.js
@@ -301,7 +301,7 @@ module.exports = class ExecutionPoker {
 
     const runtime = new HydratedRuntime();
     const steps = await runtime.run({ code, data });
-    const merkle = new Merkelizer().run(steps, bytecode, data);
+    const merkle = new Merkelizer().run(steps, bytecode, data, evmParams.customEnvironmentHash);
 
     return { steps, merkle, codeFragmentTree };
   }

--- a/utils/ProofHelper.js
+++ b/utils/ProofHelper.js
@@ -72,7 +72,7 @@ module.exports = class ProofHelper {
         data: isCallDataRequired ? prevOutput.data : '0x',
         stack: execState.compactStack,
         mem: isMemoryRequired ? prevOutput.mem : [],
-        customEnvironmentHash: ZERO_HASH,
+        customEnvironmentHash: prevOutput.customEnvironmentHash,
         returnData: prevOutput.returnData,
         pc: prevOutput.pc,
         gasRemaining: prevOutput.gasRemaining,


### PR DESCRIPTION
Pass the `customEnvironmentHash` to the relevant parts, instead of using `ZERO_HASH` placeholder