### PR TITLE
Implement resultProofs for Enforcer

### DIFF
--- a/contracts/Enforcer.sol
+++ b/contracts/Enforcer.sol
@@ -215,15 +215,15 @@ contract Enforcer is IEnforcer {
             // length in bytes of _result
             let resultBytesLen := mload(_result)
             // if `right` is zero, we use `left`
-            let hashLeft := eq(mload(rightPtr), 0)
+            let hashRightValue := mload(rightPtr)
 
-            if hashLeft {
+            if iszero(hashRightValue) {
                 // hash left
                 mstore(_result, mload(leftPtr))
             }
-            if iszero(hashLeft) {
+            if gt(hashRightValue, 0) {
                 // hash right
-                mstore(_result, mload(rightPtr))
+                mstore(_result, hashRightValue)
             }
             // the stateHash for the last leaf
             let stateHash := keccak256(_result, add(resultBytesLen, 0x20))
@@ -231,10 +231,10 @@ contract Enforcer is IEnforcer {
             mstore(_result, resultBytesLen)
 
             // store the updated value into `_resultProof`
-            if hashLeft {
+            if iszero(hashRightValue) {
                 mstore(leftPtr, stateHash)
             }
-            if iszero(hashLeft) {
+            if gt(hashRightValue, 0) {
                 mstore(rightPtr, stateHash)
             }
 

--- a/contracts/Merkelizer.slb
+++ b/contracts/Merkelizer.slb
@@ -54,19 +54,24 @@ library Merkelizer {
             _dataHash = dataHash(self.data);
         }
 
-        return keccak256(
+        bytes32 preHash = keccak256(
             abi.encodePacked(
                 _stackHash,
                 _memHash,
                 _dataHash,
                 self.customEnvironmentHash,
-                self.returnData,
                 self.pc,
                 self.gasRemaining,
                 self.stackSize,
                 self.memSize
             )
         );
+
+        // Question: before we *eventually* implement `FragmentTree` for `returnData`,
+        // should we also hash the bytelength from `returnData`.
+        // This is probably not needed because the array would be too large anyway to verify on-chain
+        // for a possible hash-collision
+        return keccak256(abi.encodePacked(preHash, self.returnData));
     }
 
     function initialStateHash(bytes32 dataHash, bytes32 customEnvironmentHash) internal pure returns (bytes32) {

--- a/test/contracts/verifier.js
+++ b/test/contracts/verifier.js
@@ -72,19 +72,22 @@ describe('Verifier', function () {
       ];
       const callData = '0x12345678';
       const { taskHash, params } = await requestExecution(enforcer, code, callData);
+      const left = '0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b';
+      const right = Merkelizer.hash(left, left);
+      const solverRoot = Merkelizer.hash(left, right);
 
       let tx = await enforcer.register(
         taskHash,
-        ZERO_HASH,
-        [ZERO_HASH],
-        ZERO_HASH,
+        solverRoot,
+        [left, left],
+        left,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
       );
 
       tx = await tx.wait();
 
       tx = await enforcer.dispute(
-        ZERO_HASH,
+        solverRoot,
         ZERO_HASH,
         params,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
@@ -139,19 +142,22 @@ describe('Verifier', function () {
       ];
       const callData = '0x12345679';
       const { taskHash, params } = await requestExecution(enforcer, code, callData);
+      const left = '0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b';
+      const right = Merkelizer.hash(left, left);
+      const solverRoot = Merkelizer.hash(left, right);
 
       let tx = await enforcer.register(
         taskHash,
-        ZERO_HASH,
-        [ZERO_HASH],
-        ZERO_HASH,
+        solverRoot,
+        [left, left],
+        left,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
       );
 
       tx = await tx.wait();
 
       tx = await enforcer.dispute(
-        ZERO_HASH,
+        solverRoot,
         ZERO_HASH,
         params,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
@@ -172,18 +178,21 @@ describe('Verifier', function () {
       ];
       const callData = '0x12345680';
       const { taskHash, params } = await requestExecution(enforcer, code, callData);
+      const left = '0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b';
+      const right = Merkelizer.hash(left, left);
+      const solverRoot = Merkelizer.hash(left, right);
 
       let tx = await enforcer.register(
         taskHash,
-        ZERO_HASH,
-        [ZERO_HASH],
-        ZERO_HASH,
+        solverRoot,
+        [left, left],
+        left,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
       );
       tx = await tx.wait();
 
       tx = await enforcer.dispute(
-        ZERO_HASH,
+        solverRoot,
         ZERO_HASH,
         params,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
@@ -212,20 +221,21 @@ describe('Verifier', function () {
       ];
       const callData = '0x12345680';
       const { taskHash, params } = await requestExecution(enforcer, code, callData);
-
-      let solverHash = Merkelizer.hash(ONE_HASH, ZERO_HASH);
+      const left = '0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b';
+      const right = Merkelizer.hash(left, left);
+      const solverRoot = Merkelizer.hash(left, right);
 
       let tx = await enforcer.register(
         taskHash,
-        solverHash,
-        [ZERO_HASH],
-        ZERO_HASH,
+        solverRoot,
+        [left, left],
+        left,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
       );
       tx = await tx.wait();
 
       tx = await enforcer.dispute(
-        solverHash,
+        solverRoot,
         ZERO_HASH,
         params,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
@@ -237,8 +247,8 @@ describe('Verifier', function () {
       tx = await verifier.respond(
         disputeId,
         {
-          left: ONE_HASH,
-          right: ZERO_HASH,
+          left: left,
+          right: right,
         },
         ZERO_WITNESS_PATH,
         { gasLimit: GAS_LIMIT }
@@ -261,19 +271,22 @@ describe('Verifier', function () {
       ];
       const callData = '0x12345680';
       const { taskHash, params } = await requestExecution(enforcer, code, callData);
+      const left = '0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b';
+      const right = Merkelizer.hash(left, left);
+      const solverRoot = Merkelizer.hash(left, right);
 
       let tx = await enforcer.register(
         taskHash,
-        ZERO_HASH,
-        [ZERO_HASH],
-        ZERO_HASH,
+        solverRoot,
+        [left, left],
+        left,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
       );
       tx = await tx.wait();
 
       let challengerHash = Merkelizer.hash(ONE_HASH, ZERO_HASH);
       tx = await enforcer.dispute(
-        ZERO_HASH,
+        solverRoot,
         challengerHash,
         params,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
@@ -311,20 +324,22 @@ describe('Verifier', function () {
       ];
       const callData = '0x12345680';
       const { taskHash, params } = await requestExecution(enforcer, code, callData);
+      const left = '0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b';
+      const right = Merkelizer.hash(left, left);
+      const solverRoot = Merkelizer.hash(left, right);
 
-      let solverHash = Merkelizer.hash(ONE_HASH, TWO_HASH);
       let tx = await enforcer.register(
         taskHash,
-        solverHash,
-        [ZERO_HASH],
-        ZERO_HASH,
+        solverRoot,
+        [left, left],
+        left,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
       );
       tx = await tx.wait();
 
       let challengerHash = Merkelizer.hash(ONE_HASH, ZERO_HASH);
       tx = await enforcer.dispute(
-        solverHash,
+        solverRoot,
         challengerHash,
         params,
         { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
@@ -337,8 +352,8 @@ describe('Verifier', function () {
       tx = await verifier.respond(
         disputeId,
         {
-          left: ONE_HASH,
-          right: TWO_HASH,
+          left: left,
+          right: right,
         },
         ZERO_WITNESS_PATH,
         { gasLimit: GAS_LIMIT }
@@ -375,19 +390,23 @@ describe('Verifier', function () {
     ];
     const callData = '0x12345679';
     const { taskHash, params } = await requestExecution(enforcer, code, callData);
+    const left = ZERO_HASH;
+    const preRight = '0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b';
+    const right = Merkelizer.hash(preRight, preRight);
+    const solverRoot = Merkelizer.hash(left, right);
 
     let tx = await enforcer.register(
       taskHash,
-      Merkelizer.hash(ZERO_HASH, ONE_HASH),
-      [ZERO_HASH],
-      ZERO_HASH,
+      solverRoot,
+      [left, preRight],
+      preRight,
       { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
     );
 
     tx = await tx.wait();
 
     tx = await enforcer.dispute(
-      Merkelizer.hash(ZERO_HASH, ONE_HASH),
+      solverRoot,
       Merkelizer.hash(ONE_HASH, ZERO_HASH),
       params,
       { value: 1, gasPrice: 0x01, gasLimit: GAS_LIMIT }
@@ -412,8 +431,8 @@ describe('Verifier', function () {
     tx = await verifier.respond(
       disputeId,
       {
-        left: ZERO_HASH,
-        right: ONE_HASH,
+        left: left,
+        right: right,
       },
       ZERO_WITNESS_PATH,
       { gasLimit: GAS_LIMIT }

--- a/utils/Merkelizer.js
+++ b/utils/Merkelizer.js
@@ -7,6 +7,8 @@ const AbstractMerkleTree = require('./AbstractMerkleTree');
 const { ZERO_HASH } = require('./constants');
 
 module.exports = class Merkelizer extends AbstractMerkleTree {
+  /// @notice If the first (left-most) hash is not the same as this,
+  /// then the solution from that player is invalid.
   static initialStateHash (code, callData, customEnvironmentHash) {
     const DEFAULT_GAS = 0x0fffffffffffff;
     const res = {
@@ -23,25 +25,13 @@ module.exports = class Merkelizer extends AbstractMerkleTree {
         stackSize: 0,
         memSize: 0,
         customEnvironmentHash: customEnvironmentHash,
+        stackHash: this.stackHash([]),
+        memHash: this.memHash([]),
+        dataHash: this.dataHash(callData),
       },
     };
 
-    // Note:
-    //   This value needs to be taken into account for the dispute logic (timeout function).
-    //   If the first (left-most) hash is not the same as this,
-    //   then the solution from that player is invalid
-
-    const stackHash = this.stackHash([]);
-    const memHash = this.memHash([]);
-    const callDataHash = this.dataHash(callData);
-
-    res.hash = this.stateHash(
-      res.executionState,
-      stackHash,
-      memHash,
-      callDataHash,
-      customEnvironmentHash
-    );
+    res.hash = this.stateHash(res.executionState);
 
     return res;
   }
@@ -99,30 +89,42 @@ module.exports = class Merkelizer extends AbstractMerkleTree {
     );
   }
 
-  static stateHash (execution, stackHash, memHash, dataHash, customEnvironmentHash) {
-    // TODO: compact returnData
-
+  static preStateHash (execution) {
     return ethers.utils.solidityKeccak256(
       [
         'bytes32',
         'bytes32',
         'bytes32',
         'bytes32',
-        'bytes',
         'uint256',
         'uint256',
         'uint256',
-        'uint256'],
+        'uint256',
+      ],
       [
-        stackHash,
-        memHash,
-        dataHash,
-        customEnvironmentHash,
-        execution.returnData,
+        execution.stackHash,
+        execution.memHash,
+        execution.dataHash,
+        execution.customEnvironmentHash,
         execution.pc,
         execution.gasRemaining,
         execution.stackSize,
         execution.memSize,
+      ]
+    );
+  }
+
+  static stateHash (execution) {
+    // TODO: compact returnData
+
+    return ethers.utils.solidityKeccak256(
+      [
+        'bytes32',
+        'bytes',
+      ],
+      [
+        this.preStateHash(execution),
+        execution.returnData,
       ]
     );
   }
@@ -147,12 +149,6 @@ module.exports = class Merkelizer extends AbstractMerkleTree {
       const exec = executions[i];
       const stackHash = exec.stackHash;
 
-      // convenience
-      exec.memSize = exec.mem.length;
-      exec.data = callData;
-      // TODO: the runtime should ultimately support and supply that
-      exec.customEnvironmentHash = customEnvironmentHash;
-
       // memory is changed if either written to or if it was expanded
       let memoryChanged = exec.memWriteLow !== -1;
       if (!memoryChanged && prevLeaf.right.executionState) {
@@ -163,7 +159,15 @@ module.exports = class Merkelizer extends AbstractMerkleTree {
         memHash = this.constructor.memHash(exec.mem);
       }
 
-      const hash = this.constructor.stateHash(exec, stackHash, memHash, callDataHash, customEnvironmentHash);
+      // convenience
+      exec.memSize = exec.mem.length;
+      exec.data = callData;
+      exec.dataHash = callDataHash;
+      exec.memHash = memHash;
+      // TODO: the runtime should ultimately support and supply that
+      exec.customEnvironmentHash = customEnvironmentHash;
+
+      const hash = this.constructor.stateHash(exec);
       const llen = leaves.push(
         {
           left: prevLeaf.right,
@@ -185,5 +189,90 @@ module.exports = class Merkelizer extends AbstractMerkleTree {
     this.recal(0);
 
     return this;
+  }
+
+  /// @notice Calculates a proof for `returnData` of the last execution step.
+  /// @return Array
+  computeResultProof () {
+    const resultProof = [];
+
+    let returnData;
+    let node = this.root;
+    while (true) {
+      let hash = node.right.hash;
+
+      if (node.isLeaf) {
+        if (node.right.hash === ZERO_HASH) {
+          const preHash = this.constructor.preStateHash(node.left.executionState);
+
+          returnData = node.left.executionState.returnData;
+          resultProof.push(preHash);
+          resultProof.push(node.right.hash);
+        } else {
+          const preHash = this.constructor.preStateHash(node.right.executionState);
+
+          returnData = node.right.executionState.returnData;
+          resultProof.push(node.left.hash);
+          resultProof.push(preHash);
+        }
+        break;
+      }
+
+      resultProof.push(node.left.hash);
+      resultProof.push(node.right.hash);
+
+      if (hash === ZERO_HASH) {
+        hash = node.left.hash;
+      }
+      node = this.getNode(hash);
+    }
+
+    return { resultProof, returnData };
+  }
+
+  /// @notice Verifies a proof from `computeResultProof`.
+  /// @return `true` if correct, else `false`
+  verifyResultProof (resultProof, returnData, rootHash) {
+    const len = resultProof.length;
+
+    if (len < 2 || (len % 2) !== 0) {
+      return false;
+    }
+
+    // save those temporarily
+    let tmpLeft = resultProof[len - 2];
+    let tmpRight = resultProof[len - 1];
+    if (tmpRight === ZERO_HASH) {
+      resultProof[len - 2] =
+        ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [tmpLeft, returnData]);
+    } else {
+      resultProof[len - 1] =
+        ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [tmpRight, returnData]);
+    }
+
+    let valid = true;
+    let parentHash = rootHash;
+    for (let i = 0; i < len; i += 2) {
+      const left = resultProof[i];
+      const right = resultProof[i + 1];
+      const hash = this.constructor.hash(left, right);
+
+      if (hash !== parentHash) {
+        valid = false;
+        break;
+      }
+
+      if (right === ZERO_HASH) {
+        parentHash = left;
+      } else {
+        parentHash = right;
+      }
+    }
+
+    // restore the values we swapped above
+    resultProof[len - 2] = tmpLeft;
+    resultProof[len - 1] = tmpRight;
+
+    return valid;
   }
 };


### PR DESCRIPTION
A important change is the hashing method of `stateHash`.
We now have `preStateHash` which includes everything except `returnData`
to compute/verify `resultProof` more efficiently.

Fixes #140